### PR TITLE
Batch of fixes for Sashimi.AzureWebApp to target Server 2020.5

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Calamari\Calamari.csproj" />
-    <PackageReference Include="Calamari.Tests.Shared" Version="8.3.4" />
+    <PackageReference Include="Calamari.Tests.Shared" Version="8.5.4" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.34.0" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.33.0" />
     <PackageReference Include="nunit" Version="3.12.0" />

--- a/source/Calamari/App.config
+++ b/source/Calamari/App.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<configuration>
+    <runtime>
+        <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
+    </runtime>
+</configuration>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -8,9 +8,9 @@
     <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.AzureScripting" Version="9.0.2" />
-    <PackageReference Include="Calamari.Common" Version="15.1.5" />
-    <PackageReference Include="Calamari.Scripting" Version="8.3.4" />
+    <PackageReference Include="Calamari.AzureScripting" Version="9.2.0" />
+    <PackageReference Include="Calamari.Common" Version="15.1.6" />
+    <PackageReference Include="Calamari.Scripting" Version="8.4.0" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="3.7.3-preview" />
     <PackageReference Include="Microsoft.Azure.Management.Websites" Version="3.0.0" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="11.0.0" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="8.6.0" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="8.6.0" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="8.5.4" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="8.5.4" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.22" />
   </ItemGroup>
 </Project>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -23,8 +23,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Octopus.Configuration" Version="2.1.0" />
-    <PackageReference Include="Sashimi.Azure.Accounts" Version="8.3.4" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="8.6.0" />
-    <PackageReference Include="Sashimi.AzureScripting" Version="9.0.2" />
+    <PackageReference Include="Sashimi.Azure.Accounts" Version="8.5.4" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="8.5.4" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="9.2.0" />
   </ItemGroup>
 </Project>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="Cake" version="0.38.5" />
+</packages>


### PR DESCRIPTION
Fixes both:
- https://github.com/OctopusDeploy/Issues/issues/6683
- https://github.com/OctopusDeploy/Issues/issues/6778

For netfull we need to explicitly enable long file paths in the config file.
Update references to Calamari + Sashimi to match what the Server is referencing
Had to lock the cake version because v1 does not work!

Cake error with v1:
![image](https://user-images.githubusercontent.com/122651/109563561-ab23ea80-7b2b-11eb-9406-c83ad9dc4a59.png)
