### PR TITLE
Update references to Calamari + Sashimi for targeting 2020.6 server

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Calamari\Calamari.csproj" />
-    <PackageReference Include="Calamari.Tests.Shared" Version="8.5.4" />
+    <PackageReference Include="Calamari.Tests.Shared" Version="8.6.4" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.34.0" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.33.0" />
-    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="nunit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.22" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Packages\**\*">

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -8,9 +8,9 @@
     <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.AzureScripting" Version="9.2.0" />
-    <PackageReference Include="Calamari.Common" Version="15.1.6" />
-    <PackageReference Include="Calamari.Scripting" Version="8.4.0" />
+    <PackageReference Include="Calamari.AzureScripting" Version="10.0.0" />
+    <PackageReference Include="Calamari.Common" Version="17.0.1" />
+    <PackageReference Include="Calamari.Scripting" Version="8.6.4" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="3.7.3-preview" />
     <PackageReference Include="Microsoft.Azure.Management.Websites" Version="3.0.0" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -8,7 +8,7 @@
     <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.AzureScripting" Version="10.0.0" />
+    <PackageReference Include="Calamari.AzureScripting" Version="10.0.1" />
     <PackageReference Include="Calamari.Common" Version="17.0.1" />
     <PackageReference Include="Calamari.Scripting" Version="8.6.4" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="3.7.3-preview" />

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -18,8 +18,7 @@
     <PackageReference Include="nunit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="11.0.0" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="8.6.4" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="8.6.4" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="8.6.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 </Project>

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -13,13 +13,13 @@
     <PackageReference Include="Microsoft.Azure.Management.AppService.Fluent" Version="1.33.0" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.33.0" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.34.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
-    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="nunit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="11.0.0" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="8.5.4" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="8.5.4" />
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.22" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="8.6.4" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="8.6.4" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 </Project>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -23,8 +23,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Octopus.Configuration" Version="2.1.0" />
-    <PackageReference Include="Sashimi.Azure.Accounts" Version="8.5.4" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="8.5.4" />
-    <PackageReference Include="Sashimi.AzureScripting" Version="9.2.0" />
+    <PackageReference Include="Sashimi.Azure.Accounts" Version="8.6.4" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="8.6.4" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -23,8 +23,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Octopus.Configuration" Version="2.1.0" />
-    <PackageReference Include="Sashimi.Azure.Accounts" Version="8.6.4" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="8.6.4" />
-    <PackageReference Include="Sashimi.AzureScripting" Version="10.0.0" />
+    <PackageReference Include="Sashimi.Azure.Accounts" Version="8.6.0" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="8.6.0" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="10.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description
This PR completes the work started in https://github.com/OctopusDeploy/Sashimi.AzureWebApp/pull/10

This PR increases the Calamari version to 17.0.1 (Server v2020.6 is still on Calamari v16.0.7), as part of merging this PR with the Server I will be bumping the Calamari version to match the one in this PR.

### Is it safe to bump Calamari to v17.0.1?
Yes I have reviewed the changes - https://github.com/OctopusDeploy/Calamari/compare/16.0.7...17.0.1