### PR TITLE
Updates Sashimi versions to include Azure bundled tools warnings

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Calamari\Calamari.csproj" />
-    <PackageReference Include="Calamari.Tests.Shared" Version="11.0.0" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.37.0" />
-    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.37.0" />
-    <PackageReference Include="nunit" Version="3.13.1" />
+    <PackageReference Include="Calamari.Tests.Shared" Version="13.3.0" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.37.1" />
+    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.37.1" />
+    <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -8,14 +8,14 @@
     <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.AzureScripting" Version="12.0.0" />
-    <PackageReference Include="Calamari.Common" Version="19.2.0" />
-    <PackageReference Include="Calamari.Scripting" Version="11.0.0" />
+    <PackageReference Include="Calamari.AzureScripting" Version="13.2.0" />
+    <PackageReference Include="Calamari.Common" Version="19.2.5" />
+    <PackageReference Include="Calamari.Scripting" Version="13.3.0" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="3.7.3-preview" />
-    <PackageReference Include="Microsoft.Azure.Management.Websites" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
+    <PackageReference Include="Microsoft.Azure.Management.Websites" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />
     <PackageReference Include="Microsoft.Web.Deployment" Version="4.0.5" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -10,16 +10,16 @@
   <ItemGroup>
     <ProjectReference Include="..\Calamari\Calamari.csproj" />
     <ProjectReference Include="..\Sashimi\Sashimi.csproj" />
-    <PackageReference Include="Microsoft.Azure.Management.AppService.Fluent" Version="1.37.0" />
-    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.37.0" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.37.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.Azure.Management.AppService.Fluent" Version="1.37.1" />
+    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.37.1" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.37.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
-    <PackageReference Include="nunit" Version="3.13.1" />
+    <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.0.1" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="13.1.0" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="13.1.0" />
+    <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.0.5" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="13.3.0" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="13.3.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 </Project>

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="nunit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.0.1" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="11.0.1" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="11.0.1" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="13.1.0" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="13.1.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 </Project>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -23,9 +23,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Octopus.Configuration" Version="3.0.0" />
-    <PackageReference Include="Sashimi.Azure.Accounts" Version="13.1.0" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="13.1.0" />
-    <PackageReference Include="Sashimi.AzureScripting" Version="13.1.2" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="13.1.0" />
+    <PackageReference Include="Sashimi.Azure.Accounts" Version="13.3.0" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="13.3.0" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="13.2.0" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="13.3.0" />
   </ItemGroup>
 </Project>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Octopus.Configuration" Version="3.0.0" />
     <PackageReference Include="Sashimi.Azure.Accounts" Version="13.1.0" />
     <PackageReference Include="Sashimi.Azure.Common" Version="13.1.0" />
-    <PackageReference Include="Sashimi.AzureScripting" Version="13.1.2-geoff-azure-tool0001" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="13.1.2" />
     <PackageReference Include="Sashimi.Server.Contracts" Version="13.1.0" />
   </ItemGroup>
 </Project>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -23,9 +23,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Octopus.Configuration" Version="3.0.0" />
-    <PackageReference Include="Sashimi.Azure.Accounts" Version="11.0.1" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="11.0.1" />
-    <PackageReference Include="Sashimi.AzureScripting" Version="12.0.0" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="11.0.1" />
+    <PackageReference Include="Sashimi.Azure.Accounts" Version="13.1.0" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="13.1.0" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="13.1.2-geoff-azure-tool0001" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="13.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR updates to use the latest Sashimi versions so as to include changes from https://github.com/OctopusDeploy/Sashimi.AzureScripting/pull/10