### PR TITLE
Bump Calamari.AzureScripting to 14.0.2

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -8,9 +8,9 @@
     <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.AzureScripting" Version="14.0.1" />
-    <PackageReference Include="Calamari.Common" Version="20.3.8" />
-    <PackageReference Include="Calamari.Scripting" Version="14.1.0" />
+    <PackageReference Include="Calamari.AzureScripting" Version="14.0.2" />
+    <PackageReference Include="Calamari.Common" Version="20.4.0" />
+    <PackageReference Include="Calamari.Scripting" Version="14.1.1" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="3.7.3-preview" />
     <PackageReference Include="Microsoft.Azure.Management.Websites" Version="3.1.1" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />


### PR DESCRIPTION
Rolling dependency changes through to keep things up to date, no functional changes in this Sashimi as it's not a "Run a Script" step.

(Version bump results from fix for OctopusDeploy/Issues#7050, which changed the way Bash Script parameters are handled)