### PR TITLE
Bumps Calamari.* to 18.1.7, Sashimi.* to 9.0.3, AzureScripting.* to 11.0.3 (Server 2021.1 stream)

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Calamari\Calamari.csproj" />
-    <PackageReference Include="Calamari.Tests.Shared" Version="9.0.2" />
+    <PackageReference Include="Calamari.Tests.Shared" Version="9.0.3" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.37.0" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.37.0" />
     <PackageReference Include="nunit" Version="3.13.1" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -8,9 +8,9 @@
     <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.AzureScripting" Version="11.0.2" />
-    <PackageReference Include="Calamari.Common" Version="18.1.4" />
-    <PackageReference Include="Calamari.Scripting" Version="9.0.2" />
+    <PackageReference Include="Calamari.AzureScripting" Version="11.0.3" />
+    <PackageReference Include="Calamari.Common" Version="18.1.7" />
+    <PackageReference Include="Calamari.Scripting" Version="9.0.3" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="3.7.3-preview" />
     <PackageReference Include="Microsoft.Azure.Management.Websites" Version="3.1.0" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="nunit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="12.1.1" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="9.0.0" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="9.0.3" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 </Project>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -23,8 +23,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Octopus.Configuration" Version="2.1.0" />
-    <PackageReference Include="Sashimi.Azure.Accounts" Version="9.0.0" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="9.0.0" />
-    <PackageReference Include="Sashimi.AzureScripting" Version="11.0.0" />
+    <PackageReference Include="Sashimi.Azure.Accounts" Version="9.0.3" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="9.0.3" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="11.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Overview
This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.1.

Upstream changes:
* OctopusDeploy/Calamari#805
* OctopusDeploy/Sashimi#130
* OctopusDeploy/Sashimi.AzureScripting#18

To fix Issues:
* OctopusDeploy/Issues#6794
* OctopusDeploy/Issues#7177