### PR TITLE
Bumps Calamari.* to 19.4.10 and Sashimi.* to 14.0.3 (Server 2021.2 stream)

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Calamari\Calamari.csproj" />
-    <PackageReference Include="Calamari.Tests.Shared" Version="14.0.1" />
+    <PackageReference Include="Calamari.Tests.Shared" Version="14.0.3" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.37.1" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.37.1" />
     <PackageReference Include="nunit" Version="3.13.2" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -8,9 +8,9 @@
     <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.AzureScripting" Version="14.0.0" />
-    <PackageReference Include="Calamari.Common" Version="19.4.6" />
-    <PackageReference Include="Calamari.Scripting" Version="14.0.1" />
+    <PackageReference Include="Calamari.AzureScripting" Version="14.0.3" />
+    <PackageReference Include="Calamari.Common" Version="19.4.10" />
+    <PackageReference Include="Calamari.Scripting" Version="14.0.3" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="3.7.3-preview" />
     <PackageReference Include="Microsoft.Azure.Management.Websites" Version="3.1.1" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.0.5" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="14.0.1" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="14.0.1" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="14.0.3" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="14.0.3" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 </Project>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -23,9 +23,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Octopus.Configuration" Version="3.0.0" />
-    <PackageReference Include="Sashimi.Azure.Accounts" Version="14.0.1" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="14.0.1" />
-    <PackageReference Include="Sashimi.AzureScripting" Version="14.0.0" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="14.0.1" />
+    <PackageReference Include="Sashimi.Azure.Accounts" Version="14.0.3" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="14.0.3" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="14.0.3" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="14.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Overview
This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.2.

Upstream changes:
* OctopusDeploy/Calamari#808
* OctopusDeploy/Sashimi#133
* OctopusDeploy/Sashimi.AzureScripting#19

To fix Issues:
* OctopusDeploy/Issues#6794
* OctopusDeploy/Issues#7177