### PR TITLE
Bumps Calamari.* to 20.4.2, Sashimi.* to 14.1.3, and Sashimi.AzureScripting to 14.1.0

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -149,6 +149,8 @@ Task("PublishSashimiTestProjects")
 		    	    	Configuration = configuration,
                         OutputDirectory = $"{publishDir}/{sashimiFlavour}"
 		    	    });
+
+                    CopyFiles("./global.json", $"{publishDir}/{sashimiFlavour}");
                 }
 
                 RunPublish();

--- a/build.cake
+++ b/build.cake
@@ -83,7 +83,7 @@ Task("Build")
 
 Task("Test")
     .IsDependentOn("Build")
-    .WithCriteria(false)
+    .WithCriteria(BuildSystem.IsLocalBuild)
     .Does(() => {
 		var projects = GetFiles("./source/**/*Tests.csproj");
 

--- a/build.cake
+++ b/build.cake
@@ -83,7 +83,7 @@ Task("Build")
 
 Task("Test")
     .IsDependentOn("Build")
-    .WithCriteria(BuildSystem.IsLocalBuild)
+    .WithCriteria(false)
     .Does(() => {
 		var projects = GetFiles("./source/**/*Tests.csproj");
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+        "version": "5.0.100",
+        "rollForward": "latestFeature"
+    }
+}

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Calamari\Calamari.csproj" />
-    <PackageReference Include="Calamari.Tests.Shared" Version="14.1.0" />
+    <PackageReference Include="Calamari.Tests.Shared" Version="14.1.3" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.37.1" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.37.1" />
     <PackageReference Include="nunit" Version="3.13.2" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -8,9 +8,9 @@
     <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.AzureScripting" Version="14.0.2" />
-    <PackageReference Include="Calamari.Common" Version="20.4.0" />
-    <PackageReference Include="Calamari.Scripting" Version="14.1.1" />
+    <PackageReference Include="Calamari.AzureScripting" Version="14.1.0" />
+    <PackageReference Include="Calamari.Common" Version="20.4.2" />
+    <PackageReference Include="Calamari.Scripting" Version="14.1.3" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="3.7.3-preview" />
     <PackageReference Include="Microsoft.Azure.Management.Websites" Version="3.1.1" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
 		<RootNamespace>Sashimi.AzureWebApp.Tests</RootNamespace>
 		<AssemblyName>Sashimi.AzureWebApp.Tests</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -17,9 +17,9 @@
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.0.5" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="14.0.1" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="14.0.1" />
+    <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.3.3" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="14.1.3" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="14.1.3" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 </Project>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -22,10 +22,10 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Configuration" Version="3.0.0" />
-    <PackageReference Include="Sashimi.Azure.Accounts" Version="14.0.1" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="14.0.1" />
-    <PackageReference Include="Sashimi.AzureScripting" Version="14.0.0" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="14.0.1" />
+    <PackageReference Include="Octopus.Configuration" Version="4.1.0" />
+    <PackageReference Include="Sashimi.Azure.Accounts" Version="14.1.3" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="14.1.3" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="14.1.0" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="14.1.3" />
   </ItemGroup>
 </Project>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Sashimi.AzureWebApp</AssemblyName>
 		<RootNamespace>Sashimi.AzureWebApp</RootNamespace>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
     <OutputPath>bin\</OutputPath>


### PR DESCRIPTION
# Overview
This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.3

Also upgrades the Sashimi and Sashimi.Tests projects to `net5.0`, cascading from [a corresponding change in `Sashimi` last year](https://github.com/OctopusDeploy/Sashimi/pull/119). This required addition of a `global.json` and some changes to the Cake script to facilitate correct framework selection on the build agents.

Upstream changes:
* OctopusDeploy/Calamari#815
* OctopusDeploy/Sashimi#134
* OctopusDeploy/Sashimi.AzureScripting#20

Issues:
* OctopusDeploy/Issues/issues/6794
* OctopusDeploy/Issues/issues/7177