### PR TITLE
Enables target discovery for Azure Web App step

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Calamari\Calamari.csproj" />
-    <PackageReference Include="Calamari.Tests.Shared" Version="14.1.3" />
+    <PackageReference Include="Calamari.Tests.Shared" Version="14.2.0" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.37.1" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.37.1" />
     <PackageReference Include="nunit" Version="3.13.2" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -8,9 +8,9 @@
     <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.AzureScripting" Version="14.1.0" />
-    <PackageReference Include="Calamari.Common" Version="20.4.2" />
-    <PackageReference Include="Calamari.Scripting" Version="14.1.3" />
+    <PackageReference Include="Calamari.AzureScripting" Version="14.2.0" />
+    <PackageReference Include="Calamari.Common" Version="21.1.0" />
+    <PackageReference Include="Calamari.Scripting" Version="14.2.0" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="3.7.3-preview" />
     <PackageReference Include="Microsoft.Azure.Management.Websites" Version="3.1.1" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
 		<RootNamespace>Sashimi.AzureWebApp.Tests</RootNamespace>
 		<AssemblyName>Sashimi.AzureWebApp.Tests</AssemblyName>
@@ -18,8 +18,8 @@
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.3.3" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="14.2.0-andrewb-enh-targ0014" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="14.1.3" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="14.2.0" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="14.2.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 </Project>

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.3.3" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="14.1.3" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="14.2.0-andrewb-enh-targ0014" />
     <PackageReference Include="Sashimi.Tests.Shared" Version="14.1.3" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>

--- a/source/Sashimi/AzureWebAppActionHandler.cs
+++ b/source/Sashimi/AzureWebAppActionHandler.cs
@@ -2,6 +2,7 @@
 using Octopus.CoreUtilities;
 using Octopus.Server.Extensibility.HostServices.Diagnostics;
 using Sashimi.AzureScripting;
+using Sashimi.Server.Contracts;
 using Sashimi.Server.Contracts.ActionHandlers;
 
 namespace Sashimi.AzureWebApp
@@ -17,6 +18,7 @@ namespace Sashimi.AzureWebApp
         public bool CanRunOnDeploymentTarget => false;
         public ActionHandlerCategory[] Categories => new[] { ActionHandlerCategory.BuiltInStep, AzureConstants.AzureActionHandlerCategory, ActionHandlerCategory.Package };
         public string[] StepBasedVariableNameForAccountIds { get; } = {SpecialVariables.Action.Azure.AccountId};
+        public DeploymentTargetType DeploymentTargetType => AzureWebAppEndpoint.AzureWebAppDeploymentTargetType;
 
         public IActionHandlerResult Execute(IActionHandlerContext context, ITaskLog taskLog)
         {

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -23,9 +23,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Octopus.Configuration" Version="4.1.0" />
-    <PackageReference Include="Sashimi.Azure.Accounts" Version="14.1.3" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="14.1.3" />
+    <PackageReference Include="Sashimi.Azure.Accounts" Version="14.2.0-andrewb-enh-targ0014" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="14.2.0-andrewb-enh-targ0014" />
     <PackageReference Include="Sashimi.AzureScripting" Version="14.1.0" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="14.1.3" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="14.2.0-andrewb-enh-targ0014" />
   </ItemGroup>
 </Project>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Octopus.Configuration" Version="4.1.0" />
     <PackageReference Include="Sashimi.Azure.Accounts" Version="14.2.0" />
     <PackageReference Include="Sashimi.Azure.Common" Version="14.2.0" />
-    <PackageReference Include="Sashimi.AzureScripting" Version="14.1.0" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="14.2.0" />
     <PackageReference Include="Sashimi.Server.Contracts" Version="14.2.0" />
   </ItemGroup>
 </Project>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -23,9 +23,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Octopus.Configuration" Version="4.1.0" />
-    <PackageReference Include="Sashimi.Azure.Accounts" Version="14.2.0-andrewb-enh-targ0014" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="14.2.0-andrewb-enh-targ0014" />
+    <PackageReference Include="Sashimi.Azure.Accounts" Version="14.2.0" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="14.2.0" />
     <PackageReference Include="Sashimi.AzureScripting" Version="14.1.0" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="14.2.0-andrewb-enh-targ0014" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="14.2.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
As part of #project-dynamic-infrastructure we are adding support for discovering Azure Web App deployment targets. These targets are used by both the Azure App Service and Azure Web App steps.

This PR enables target discovery for Azure Web App steps by connecting the step with the Azure Web App deployment target type. The Sashimi PR https://github.com/OctopusDeploy/Sashimi/pull/132 needs to be completed and package references updated here before this can be shipped.

The discovery mechanism for the target is part of the AzureAppService repo and is being added in https://github.com/OctopusDeploy/Sashimi.AzureAppService/pull/24.