### PR TITLE
Update azure signtools to 3.0.0 used in build

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -3,7 +3,7 @@
 //////////////////////////////////////////////////////////////////////
 #module nuget:?package=Cake.DotNetTool.Module&version=0.4.0
 #tool "dotnet:?package=GitVersion.Tool&version=5.3.5"
-#tool "dotnet:?package=AzureSignTool&version=2.0.17"
+#tool "dotnet:?package=AzureSignTool&version=3.0.0"
 #addin "Cake.FileHelpers&version=3.2.0"
 #addin "nuget:?package=Cake.Incubator&version=5.0.1"
 #addin "nuget:?package=Cake.FileHelpers&version=4.0.1"
@@ -21,6 +21,7 @@ var signFiles = Argument<bool>("sign_files", false);
 var signToolPath = MakeAbsolute(File("./certificates/signtool.exe"));
 var keyVaultUrl = Argument("AzureKeyVaultUrl", "");
 var keyVaultAppId = Argument("AzureKeyVaultAppId", "");
+var keyVaultTenantId = Argument("AzureKeyVaultTenantId", "");
 var keyVaultAppSecret = Argument("AzureKeyVaultAppSecret", "");
 var keyVaultCertificateName = Argument("AzureKeyVaultCertificateName", "");
 ///////////////////////////////////////////////////////////////////////////////
@@ -235,7 +236,7 @@ private void SignAndTimestampBinaries(string outputDirectory)
         .ToArray();
 
     Information("Signing files using azuresigntool and the production code signing certificate");
-    SignFilesWithAzureSignTool(unsignedExecutablesAndLibraries, keyVaultUrl, keyVaultAppId, keyVaultAppSecret, keyVaultCertificateName);
+    SignFilesWithAzureSignTool(unsignedExecutablesAndLibraries, keyVaultUrl, keyVaultAppId, keyVaultAppSecret, keyVaultTenantId, keyVaultCertificateName);
 
     TimeStampFiles(unsignedExecutablesAndLibraries);
 }
@@ -255,13 +256,14 @@ private bool HasAuthenticodeSignature(FilePath filePath)
     }
 }
 
-void SignFilesWithAzureSignTool(IEnumerable<FilePath> files, string vaultUrl, string vaultAppId, string vaultAppSecret, string vaultCertificateName, string display = "", string displayUrl = "")
+void SignFilesWithAzureSignTool(IEnumerable<FilePath> files, string vaultUrl, string vaultAppId, string vaultAppSecret, string vaultTenantId, string vaultCertificateName, string display = "", string displayUrl = "")
 {
     var signArguments = new ProcessArgumentBuilder()
         .Append("sign")
         .Append("--azure-key-vault-url").AppendQuoted(vaultUrl)
         .Append("--azure-key-vault-client-id").AppendQuoted(vaultAppId)
         .Append("--azure-key-vault-client-secret").AppendQuotedSecret(vaultAppSecret)
+        .Append("--azure-key-vault-tenant-id").AppendQuotedSecret(vaultTenantId)
         .Append("--azure-key-vault-certificate").AppendQuoted(vaultCertificateName)
         .Append("--file-digest sha256");
 

--- a/build.ps1
+++ b/build.ps1
@@ -54,6 +54,7 @@ Param(
     [string]$AzureKeyVaultUrl,
     [string]$AzureKeyVaultAppId,
     [string]$AzureKeyVaultAppSecret,
+    [string]$AzureKeyVaultTenantId,
     [string]$AzureKeyvaultCertificateName,
     [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
     [string[]]$ScriptArgs
@@ -195,5 +196,5 @@ Write-Host "Installing cake modules using the --bootstrap argument"
 
 # Start Cake
 Write-Host "Running build script..."
-Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" -AzureKeyVaultUrl=`"$AzureKeyVaultUrl`" -AzureKeyVaultAppId=`"$AzureKeyVaultAppId`" -AzureKeyVaultAppSecret=`"$AzureKeyVaultAppSecret`" -AzureKeyvaultCertificateName=`"$AzureKeyvaultCertificateName`" $UseMono $UseDryRun $UseExperimental $ScriptArgs"
+Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" -AzureKeyVaultUrl=`"$AzureKeyVaultUrl`" -AzureKeyVaultAppId=`"$AzureKeyVaultAppId`" -AzureKeyVaultAppSecret=`"$AzureKeyVaultAppSecret`" -AzureKeyVaultTenantId=`"$AzureKeyVaultTenantId`" -AzureKeyvaultCertificateName=`"$AzureKeyvaultCertificateName`" $UseMono $UseDryRun $UseExperimental $ScriptArgs"
 exit $LASTEXITCODE


### PR DESCRIPTION
Bumping Azure Sign Tool version used in our build which supports netcoreapp3.1, as our build agents no longer support netstandard2.1.